### PR TITLE
fix: Prevent null pointer dereference when rateLimit attachable is missing

### DIFF
--- a/src/core/RouteNode.cpp
+++ b/src/core/RouteNode.cpp
@@ -98,7 +98,7 @@ ProcessEntry* RouteNode::getattachable(NodeDependencies& dependencyList)
 				RateLimitNode* rateLimitNode = static_cast<RateLimitNode*>(this->getDependency(&rateLimitDep));
 				if (rateLimitNode == nullptr) {
 					ServerApplication->sendResponse("HTTP/1.1 500 Internal Server Error\nContent-Type: text/html\n\n<html><body><h1>500 Internal Server Error</h1></body></html>");
-					//continue;
+					return;
 				}
 				rateLimitNode->addNewIpaddress(conReq.getIpAddress());
 


### PR DESCRIPTION
### Overview
Resolves an issue where using a `rateLimit` tag that references a non-existent node causes the server to crash (Issue #11).

### The Fix
In `RouteNode.cpp`, if the `rateLimitNode` is not found (`nullptr`), the execution previously fell through because `//continue;` was commented out inside the lambda. This caused a guaranteed null pointer dereference when calling `rateLimitNode->addNewIpaddress()`. 

I replaced the commented-out `continue` with a `return;` statement. The server now cleanly halts the execution path, sends the 500 Internal Server Error, and stays alive without crashing.

Fixes #11