### PR TITLE
Changed `receiveData()` to read the full request 

### DIFF
--- a/src/net/serversock.cpp
+++ b/src/net/serversock.cpp
@@ -80,6 +80,7 @@ SOCKET Celeris::ServerSocket::acceptConnection(CleanSocket* tcpSocketIPV4) {
 
 std::string Celeris::ServerSocket::receiveData(SOCKET clientSocket) { //we do not use a clean socket here?
 	char buf[4096];
+	std::string data;
 
 #if PLATFORM_WINDOWS
 	ZeroMemory(buf, (sizeof(char) * 4096));
@@ -88,7 +89,12 @@ std::string Celeris::ServerSocket::receiveData(SOCKET clientSocket) { //we do no
 	memset(buf, 0, (sizeof(char) * 4096));
 #endif
 
-	int bytesReceived = recv(clientSocket, buf, 4096, 0);
+	ssize_t bytesReceived = 0;
+	do {
+		bytesReceived = recv(clientSocket, buf, 4096, 0);
+		data.append(buf, bytesReceived);
+	} while (bytesReceived >= 4096);
+
 #if PLATFORM_WINDOWS
 	if (bytesReceived == SOCKET_ERROR) {
 		throw std::system_error(WSAGetLastError(), std::system_category());
@@ -102,7 +108,7 @@ std::string Celeris::ServerSocket::receiveData(SOCKET clientSocket) { //we do no
 	}
 #endif // 0
 
-	return std::string(buf, 0, bytesReceived);
+	return data;
 }
 
 void Celeris::ServerSocket::sendData(SOCKET& clientSocket, const char data[]) {

--- a/src/net/serversock.cpp
+++ b/src/net/serversock.cpp
@@ -89,9 +89,9 @@ std::string Celeris::ServerSocket::receiveData(SOCKET clientSocket) { //we do no
 	memset(buf, 0, (sizeof(char) * 4096));
 #endif
 
-	ssize_t bytesReceived = 0;
+	int bytesReceived = 0;
 	do {
-		bytesReceived = recv(clientSocket, buf, 4096, 0);
+		bytesReceived = static_cast<int>(recv(clientSocket, buf, 4096, 0));
 		data.append(buf, bytesReceived);
 	} while (bytesReceived >= 4096);
 


### PR DESCRIPTION
Changed `receiveData()` to first read the entirety of the header, and then read the remaining body of a request, using the parsed Content-Length in the header